### PR TITLE
fixing healthcheck which was breaking due to jsonify error

### DIFF
--- a/workshop-1/app/like-service/service/mysfits_like.py
+++ b/workshop-1/app/like-service/service/mysfits_like.py
@@ -14,7 +14,11 @@ CORS(app)
 # sent to the service root will receive a healthy response.
 @app.route("/")
 def health_check_response():
-    return jsonify({"message" : "Nothing here, used for health check."})
+    flaskResponse = Response(response='{"message" : "Nothing here, used for health check. Try /mysfits instead."}', status=200)
+    flaskResponse.headers["Content-Type"] = "application/json"
+    
+    return flaskResponse
+
 # indicate that the provided mysfit should be marked as liked.
 
 def process_like_request():

--- a/workshop-1/app/monolith-service/service/mythicalMysfitsService.py
+++ b/workshop-1/app/monolith-service/service/mythicalMysfitsService.py
@@ -13,7 +13,10 @@ CORS(app)
 # sent to the service root will receive a healthy response.
 @app.route("/")
 def healthCheckResponse():
-    return jsonify({"message" : "Nothing here, used for health check. Try /mysfits instead."})
+    flaskResponse = Response(response='{"message" : "Nothing here, used for health check. Try /mysfits instead."}', status=200)
+    flaskResponse.headers["Content-Type"] = "application/json"
+    
+    return flaskResponse
 
 # Retrive mysfits from DynamoDB based on provided querystring params, or all
 # mysfits if no querystring is present.

--- a/workshop-2/app/like-service/service/mysfits_like.py
+++ b/workshop-2/app/like-service/service/mysfits_like.py
@@ -11,7 +11,10 @@ CORS(app)
 # sent to the service root will receive a healthy response.
 @app.route("/")
 def health_check_response():
-    return jsonify({"message" : "Nothing here, used for health check."})
+    flaskResponse = Response(response='{"message" : "Nothing here, used for health check. Try /mysfits instead."}', status=200)
+    flaskResponse.headers["Content-Type"] = "application/json"
+
+    return flaskResponse
 # indicate that the provided mysfit should be marked as liked.
 
 def process_like_request():

--- a/workshop-2/app/monolith-service/service/mythicalMysfitsService.py
+++ b/workshop-2/app/monolith-service/service/mythicalMysfitsService.py
@@ -10,7 +10,10 @@ CORS(app)
 # sent to the service root will receive a healthy response.
 @app.route("/")
 def healthCheckResponse():
-    return jsonify({"message" : "Nothing here, used for health check. Try /mysfits instead."})
+    flaskResponse = Response(response='{"message" : "Nothing here, used for health check. Try /mysfits instead."}', status=200)
+    flaskResponse.headers["Content-Type"] = "application/json"
+
+    return flaskResponse
 
 # Retrive mysfits from DynamoDB based on provided querystring params, or all
 # mysfits if no querystring is present.

--- a/workshop-3/app/monolith-service/service/mythicalMysfitsService.py
+++ b/workshop-3/app/monolith-service/service/mythicalMysfitsService.py
@@ -10,7 +10,10 @@ CORS(app)
 # sent to the service root will receive a healthy response.
 @app.route("/")
 def healthCheckResponse():
-    return jsonify({"message" : "Nothing here, used for health check. Try /mysfits instead."})
+    flaskResponse = Response(response='{"message" : "Nothing here, used for health check. Try /mysfits instead."}', status=200)
+    flaskResponse.headers["Content-Type"] = "application/json"
+
+    return flaskResponse
 
 # Retrive mysfits from DynamoDB based on provided querystring params, or all
 # mysfits if no querystring is present.


### PR DESCRIPTION

*Issue #, if available:*
The jsonify call was erroring with the message "'Request' object has no attribute 'is_xhr'" - potentially due to recent deprecation.

*Description of changes:*
This causes the / page to return a 500 error, which was causing the ALB in the tutorial to fail. have replaced with output that will not fail the check, and produces the same message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
