### PR TITLE
Update Dockerfiles to build with python3, update urlparse import for …

### DIFF
--- a/workshop-1/app/like-service/Dockerfile
+++ b/workshop-1/app/like-service/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu:latest
 RUN echo Updating existing packages, installing and upgrading python and pip.
 RUN apt-get update -y
-RUN apt-get install -y python-pip python-dev build-essential
-RUN pip install --upgrade pip
+RUN apt-get install -y python3-pip python-dev build-essential
+RUN pip3 install --upgrade pip
 RUN echo Copying the Mythical Mysfits Flask service into a service directory.
 COPY ./service /MythicalMysfitsService
 WORKDIR /MythicalMysfitsService
 RUN echo Installing Python packages listed in requirements.txt
-RUN pip install -r ./requirements.txt
+RUN pip3 install -r ./requirements.txt
 RUN echo Starting python and starting the Flask service...
-ENTRYPOINT ["python"]
+ENTRYPOINT ["python3"]
 CMD ["mysfits_like.py"]

--- a/workshop-1/app/like-service/service/mysfits_like.py
+++ b/workshop-1/app/like-service/service/mysfits_like.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import os
 import sys
 import requests
-from urlparse import urlparse
+from urllib.parse import urlparse
 from flask import Flask, jsonify, json, Response, request
 from flask_cors import CORS
 

--- a/workshop-1/app/like-service/service/requirements.txt
+++ b/workshop-1/app/like-service/service/requirements.txt
@@ -1,3 +1,3 @@
 Flask==1.0.0
 flask-cors==3.0.0
-requests==1.2.3
+requests==2.20.0

--- a/workshop-1/app/monolith-service/Dockerfile.draft
+++ b/workshop-1/app/monolith-service/Dockerfile.draft
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 RUN apt-get update -y
-RUN apt-get install -y python-pip python-dev build-essential
-RUN pip install --upgrade pip
+RUN apt-get install -y python3-pip python-dev build-essential
+RUN pip3 install --upgrade pip
 #[TODO]: Copy python source files and requirements file into container image
 
 #[TODO]: Install dependencies listed in the requirements.txt file using pip


### PR DESCRIPTION
Update Dockerfiles to build with python3, update urlparse import for python3 and move to compatible/more recent version of requests library.

*Issue #, if available:*

* https://github.com/aws-samples/amazon-ecs-mythicalmysfits-workshop/issues/25

*Description of changes:*

* Python2 is no longer configured as the default with Ubuntu and this is causing the current Docker build to fail.  To resolve this I've updated the build to use python3 (similar to this [PR](https://github.com/aws-samples/amazon-ecs-mythicalmysfits-workshop/pull/24/files))
* The location of the `urlparse` method was changed in Python3,  I've updated the import statement in `mysfits_like.py` with the new location (see https://stackoverflow.com/questions/29358403/no-module-named-urllib-parse-how-should-i-install-it)
* [dependabot is correct](https://github.com/aws-samples/amazon-ecs-mythicalmysfits-workshop/pull/14), an updated version of the requests library is required for the like-service to function properly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
