### PR TITLE
Use `ecr get-login-password` for AWS CLI v2

### DIFF
--- a/workshop-2/Lab-4/hints/buildspec_clair.yml
+++ b/workshop-2/Lab-4/hints/buildspec_clair.yml
@@ -18,8 +18,7 @@ phases:
  
       # Getting our Docker registry (ECR) login info for Klar and Clair to use
       - echo Getting Docker registry login info
-      - DOCKER_LOGIN=`aws ecr get-login --region $AWS_DEFAULT_REGION`
-      - PASSWORD=`echo $DOCKER_LOGIN | cut -d' ' -f6`
+      - PASSWORD=`aws ecr get-login-password --region $AWS_DEFAULT_REGION`
   build:
     commands:
       - echo Calling Clair with Klar


### PR DESCRIPTION
*Description of changes:*

Use `eco get-login-password` instead for AWS CLI v2.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
