### PR TITLE
fixing Flask==1.1.4 and adding markupsafe==2.0.1

### DIFF
--- a/workshop-1/app/like-service/service/requirements.txt
+++ b/workshop-1/app/like-service/service/requirements.txt
@@ -1,3 +1,6 @@
-Flask==1.0.0
+Flask==1.1.4
 flask-cors==3.0.0
 requests==2.20.0
+markupsafe==2.0.1
+
+


### PR DESCRIPTION
*Issue #, if available:* 
#49 (for also on like service)

*Description of changes:*
Updated requirements.txt for like service to include fixing Flask==1.1.4 and adding markupsafe==2.0.1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
